### PR TITLE
Double splat hash args

### DIFF
--- a/lib/ads_pub_sub.rb
+++ b/lib/ads_pub_sub.rb
@@ -8,7 +8,7 @@ module AdsPubSub
     end
 
     def publish(topic, message, opts = {})
-      @service.publish(topic, message)
+      @service.publish(topic, message, opts)
     end
 
     def subscribe(subscription, &block)

--- a/lib/ads_pub_sub/google_pub_sub.rb
+++ b/lib/ads_pub_sub/google_pub_sub.rb
@@ -46,7 +46,7 @@ module AdsPubSub
     end
 
     def topic(name, opts = {})
-      topics[name] ||= pubsub.topic("#{base_project_path}/topics/#{name}", opts)
+      topics[name] ||= pubsub.topic("#{base_project_path}/topics/#{name}", **opts)
     end
 
     def subscription(name)


### PR DESCRIPTION
Ruby 3.0 will have issues with this arguments resulting in a invalid arguments on topic method.

The double splat fixes the issue